### PR TITLE
travis.yml: improve shellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
 env:
   global:
     - PORTAGE_VER="2.3.40"
-    - PATH="/tmp/shellcheck-latest:$PATH"
 before_install:
     - sudo apt-get -qq update
     - pip install lxml pyyaml
@@ -17,7 +16,6 @@ before_script:
     - mkdir -p travis-overlay /etc/portage /usr/portage/distfiles
     - mv !(travis-overlay) travis-overlay/
     - mv .git travis-overlay/
-    - wget -c https://goo.gl/ZzKHFv -O - | tar -xvJ -C /tmp/
     - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/.travis.yml" -O .travis.yml.upstream
     - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/spinner.sh"
     - wget -qO - "https://github.com/gentoo/portage/archive/portage-${PORTAGE_VER}.tar.gz" | tar xz
@@ -31,4 +29,5 @@ before_script:
     - cd travis-overlay
 script:
     - ./../spinner.sh "python ../portage-portage-${PORTAGE_VER}/repoman/bin/repoman full -dx"
-    - shellcheck -s bash -e "SC2034,SC2016,SC2191,SC2037" $(find . -maxdepth 3 -type f -name "*.ebuild" -o -name "*.initd")
+    - shellcheck -s bash -e "SC2034,SC2016,SC2191" */*/*.ebuild
+    - shellcheck -s sh -e "SC1008,SC2034,SC2016,SC2191" */*/*/*.initd*


### PR DESCRIPTION
Based on the observations I made in SpiderX/portage-ci#1:

- Travis has native shellcheck support. So let's remove the redundancy.
- No more 'find'. Shellcheck is almost an A.I. now.
- init scripts shouldn't have bashisms. The latest (stable) portage
  started to complain about it.
- Remove 'SC2037', as it's really bad to ignore those checks. Also,
  I din't found any violations against it.