### PR TITLE
fix broken ebuild net-voip/linphone-desktop-5.2.6

### DIFF
--- a/net-voip/linphone-desktop/linphone-desktop-5.2.6.ebuild
+++ b/net-voip/linphone-desktop/linphone-desktop-5.2.6.ebuild
@@ -74,6 +74,9 @@ src_prepare() {
 	sed -i '/SpellChecker/d' linphone-app/src/app/App.cpp \
 		|| die "sed failed for App.cpp"
 
+	# make plugins headers visible
+	ln -s "${S}/linphone-app/include/LinphoneApp" "${S}/linphone-app/src/LinphoneApp"
+
 	cmake_src_prepare
 }
 


### PR DESCRIPTION
fixed broken ebuild net-voip/linphone-desktop-5.2.6, see issue https://github.com/SpiderX/portage-overlay/issues/158

i described what i did in the comment at the ebuild file